### PR TITLE
refactor: enabling the usage with newer stylelint versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "eslint-config-node/eslint": "^5.0.0"
   },
   "peerDependencies": {
-    "stylelint": "^11.1.1"
+    "stylelint": "^11.1.1 || ^12.0.0 || ^13.0.0"
   }
 }


### PR DESCRIPTION
First of all thanks a lot for your great plugin.

I'd like to contribute by allowing the peerDependency of stylelint greater version 11, as requested by the two following tickets and necessary as this is a potential (sub)dependency in projects using stylelint greater version 11 (like the current version 13). I hope that there's nothing that speaks against using your plugin with stylelint version 12 or 13.

I borrowed this pattern on how to describe the peerDependencies up to the latest version of stylelint by other styleling plugins that updated their plugin definitions as well.

Closing #8 and #10