### PR TITLE
Fix font family bug

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -126,6 +126,21 @@ Object {
 }
 `;
 
+exports[`stylelint-no-indistinguishable-colors no side-effects should ignore color names in font-family 1`] = `
+Object {
+  "Result": Array [
+    Object {
+      "deprecations": Array [],
+      "errored": false,
+      "invalidOptionWarnings": Array [],
+      "parseErrors": Array [],
+      "source": StringMatching /\\^<input\\.\\*css\\.\\*>\\$/,
+      "warnings": Array [],
+    },
+  ],
+}
+`;
+
 exports[`stylelint-no-indistinguishable-colors threshold should set higher threshold 1`] = `
 Object {
   "Result": Array [

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -291,4 +291,26 @@ describe("stylelint-no-indistinguishable-colors", () => {
       });
     });
   });
+
+  describe("no side-effects", () => {
+    it("should ignore color names in font-family", async () => {
+      const rules = {
+        [ruleName]: true,
+      };
+      const code = `div { background: #fff; font-family: "Arial Black"; }`;
+
+      const result = await lint(getOptions(code, rules));
+      expect(result.errored).toBe(false);
+      expect({ Result: JSON.parse(result.output) }).toMatchSnapshot({
+        Result: Array(1).fill({
+          deprecations: [],
+          errored: false,
+          invalidOptionWarnings: [],
+          parseErrors: [],
+          source: expect.stringMatching("^<input.*css.*>$"),
+          warnings: [],
+        }),
+      });
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
-        "colorguard-processor": "1.0.48"
+        "colorguard-processor": "1.0.33"
       },
       "devDependencies": {
         "@swc/core": "^1.3.62",
@@ -1831,8 +1831,9 @@
       "license": "MIT"
     },
     "node_modules/colorguard-processor": {
-      "version": "1.0.48",
-      "license": "Apache-2.0",
+      "version": "1.0.33",
+      "resolved": "https://registry.npmjs.org/colorguard-processor/-/colorguard-processor-1.0.33.tgz",
+      "integrity": "sha512-lr2tTn0jKy7NICJonKqp/qXMAN2XeB5yWuSm+WeRz2wHvPmDTEoBwZ92UDiPUgAwK88fARQHfV3FCPh0DZPN2g==",
       "engines": {
         "node": ">=14.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-no-indistinguishable-colors",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Stylelint plugin to add rule no-indistinguishable-colors",
   "keywords": [
     "stylelint-plugin"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "colorguard-processor": "1.0.48"
+    "colorguard-processor": "1.0.33"
   },
   "devDependencies": {
     "@swc/core": "^1.3.62",


### PR DESCRIPTION
Resolves: https://github.com/ierhyna/stylelint-no-indistinguishable-colors/issues/19

Tested colorguard-processor v2.0.31 and this one also doesn't reproduce the bug described above. However, colorguard-processor v2+ dropped support for node 14 and 16. So didn't want to push that awaiting https://github.com/ierhyna/stylelint-no-indistinguishable-colors/pull/18